### PR TITLE
Add blank target to anchors

### DIFF
--- a/app/templates/track-viewer.component.html
+++ b/app/templates/track-viewer.component.html
@@ -2,7 +2,7 @@
 <h2>{{ctrack.topic}}</h2>
 <dl *ngIf="ctrack.items">
 <span *ngFor="#item of ctrack.items">
-	<dt><a href="{{item.url}}" style="font-size: 18px">{{item.title}}</a></dt>
+	<dt><a href="{{item.url}}" target="_blank" style="font-size: 18px">{{item.title}}</a></dt>
 	<dd>{{item.comment}}</dd>
 </span>
 </dl>


### PR DESCRIPTION
Adds target="_blank" to anchors, so links are opened in new tabs.
